### PR TITLE
Show block library on local server and preview URL

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -4,7 +4,7 @@
       {
         "id": "library",
         "title": "Library",
-        "environments": ["edit"],
+        "environments": ["dev", "edit", "preview"],
         "url": "/tools/sidekick/library.html",
         "includePaths": ["**.docx**"]
       }


### PR DESCRIPTION
Currently, block library sidekick plugin shows only in edit mode i.e. when a document is opened. We should also be able to open it on preview page in development mode and aem.page domain.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--{repo}--{owner}.aem.live/
- After: https://<branch>--{repo}--{owner}.aem.live/
