### PR TITLE
@fix : Use breadcrumbs-title-override when breadcrumbs text is different from page title

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -27,7 +27,7 @@ const getPageTitle = async (url) => {
     html.innerHTML = await resp.text();
     const pageTitle = html.querySelector('meta[name="page-title"]');
     if (pageTitle) {
-      return html.querySelector('meta[name="page-title"]').content;
+      return html.querySelector('meta[name="breadcrumbs-title-override"]')?.content || html.querySelector('meta[name="page-title"]').content;
     }
     return html.querySelector('title').innerText;
   }
@@ -64,7 +64,7 @@ async function buildBreadcrumbsFromNavTree(nav, currentUrl) {
   // TODO: no link on home icon
   const homeUrl = document.querySelector('.nav-brand a[href]')?.href || window.location.origin;
   if (currentUrl !== homeUrl) {
-    crumbs.push({ title: getMetadata('page-title'), url: currentUrl });
+    crumbs.push({ title: getMetadata('breadcrumbs-title-override') || getMetadata('page-title'), url: currentUrl });
   }
 
   // TODO: needs placeholders file


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--clarkcountynv--aemsites.aem.page/government/board_of_county_commissioners/district_b/meet-the-team
- After: https://breadcrumbs-fix--clarkcountynv--aemsites.aem.page/government/board_of_county_commissioners/district_b/meet-the-team
