### PR TITLE
fix: Styling fixes for parks pages

### DIFF
--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -74,6 +74,12 @@
   width: 50%;
 }
 
+.table.col1-15 table tbody tr {
+    td:first-child {
+        width: 15%;
+    }
+}
+
 .table.type2border {
     table {
         border-collapse: collapse;
@@ -293,4 +299,9 @@
             margin: unset;
         }
     }
+}
+
+.table.no-padding table tbody tr td p {
+    padding: 0;
+    margin: 0;
 }

--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -30,4 +30,8 @@ main .block.text {
     &.img-medium img{
         width: 50%;
     }
+
+    &.highlight-color-yellow {
+        background-color: #f1c40f;
+    }
 }

--- a/blocks/video/video.css
+++ b/blocks/video/video.css
@@ -79,3 +79,8 @@
     margin-top: 50px;
     margin-bottom: 0;
   }
+
+.video.right-align {
+    width: 560px;
+    float: inline-end;
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -748,3 +748,11 @@ main > div.section.newsdetail > .default-content-wrapper > p {
     text-decoration: underline;
     border: 0;
 }
+
+.image-full-width img {
+    width: 100% !important;
+}
+
+.image-half-width img {
+    width: 50% !important;
+}

--- a/templates/default/default.css
+++ b/templates/default/default.css
@@ -221,7 +221,7 @@ main .mainmenu .rightsection.special-words.orange span.special {
     font-weight: 600;
 }
 
-main .mainmenu .rightsection.image-center picture, main .mainmenu .rightsection.image-center picture img {
+main .mainmenu .rightsection.image-center picture img {
   display: block;
   margin-left: auto;
   margin-right: auto;

--- a/tools/importer/utils.js
+++ b/tools/importer/utils.js
@@ -228,7 +228,8 @@ export const fixImageSrcPath = (src, results, imagePath = 'general') => {
 
 export const fixImageLinks = (main, results, imagePath = 'general') => {
   main.querySelectorAll('img').forEach((image) => {
-    const src = image.getAttribute('src');
+    let src = image.getAttribute('src');
+    src = src.replaceAll(',', '');
     const newSrcPath = fixImageSrcPath(src, results, imagePath);
     image.setAttribute('src', newSrcPath);
   });

--- a/tools/importer/utils.js
+++ b/tools/importer/utils.js
@@ -61,6 +61,7 @@ export const fixRelativeLinks = (document) => {
 export const getImportPagePath = (url) => {
   let path = new URL(url).pathname;
   path = path.endsWith('.php') ? path.slice(0, -4) : path;
+  path = path.replaceAll(',', '');
   const pathParts = path.split('/');
   pathParts[pathParts.length - 1] = WebImporter.FileUtils.sanitizeFilename(
     pathParts[pathParts.length - 1],
@@ -85,6 +86,7 @@ export const getSanitizedPath = (url) => {
   let path = url;
 
   path = path.endsWith('.php') ? path.slice(0, -4) : path;
+  path = path.replaceAll(',', '');
   const pathParts = path.split('/');
   if (pathParts[pathParts.length - 1] === 'index') {
     pathParts.pop();
@@ -125,7 +127,8 @@ export const fixPdfLinks = (main, results, pagePath, assetPath = 'general') => {
   const EXCLUDE_EXTENSIONS = ['php', 'gov', 'org'];
 
   main.querySelectorAll('a').forEach((a) => {
-    const href = a.getAttribute('href').replace('gov//', 'gov/');
+    let href = a.getAttribute('href').replace('gov//', 'gov/');
+    href = href.replaceAll(',', '');
     const url = new URL(href, window.location.origin);
     const extension = url.pathname.split('.').pop().toLowerCase();
     if (href) {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--clarkcountynv--aemsites.aem.page/government/departments/parks___recreation/facilities/pickle-ball-courts
- After: https://styling-fixes-parks--clarkcountynv--aemsites.aem.page/government/departments/parks___recreation/facilities/pickle-ball-courts
- Before: https://main--clarkcountynv--aemsites.aem.page/government/departments/parks___recreation/facilities/bunkerville
- After: https://styling-fixes-parks--clarkcountynv--aemsites.aem.page/government/departments/parks___recreation/facilities/bunkerville
- Before: https://main--clarkcountynv--aemsites.aem.page/government/departments/parks___recreation/facilities/hollywood-early-childhood-enrichment-program
- After: https://styling-fixes-parks--clarkcountynv--aemsites.aem.page/government/departments/parks___recreation/facilities/hollywood-early-childhood-enrichment-program
- Before: https://main--clarkcountynv--aemsites.aem.page/government/departments/parks___recreation/facilities/paradise-recreation-center-special-events
- After: https://styling-fixes-parks--clarkcountynv--aemsites.aem.page/government/departments/parks___recreation/facilities/paradise-recreation-center-special-events
