### PR TITLE
Fixing the document center impact from decorate links

### DIFF
--- a/templates/default/default.js
+++ b/templates/default/default.js
@@ -11,7 +11,7 @@ import { createOptimizedPicture } from '../../scripts/aem.js';
 export function decorateLinks(element) {
   element.querySelectorAll('a').forEach((a) => {
     // match text inside [] and split by '|'
-    const match = a.textContent.match(/(.*)\[([^\]]*)]/);
+    const match = a.textContent.match(/(.*)\[\[([^\]\]]*)]/);
     if (match) {
       // eslint-disable-next-line no-unused-vars
       const [_, linkText, attrs] = match;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #377 

Test URLs:
- Before: https://main--clarkcountynv--aemsites.aem.live/government/american_rescue_plan_act/
- After: https://issue-377--clarkcountynv--aemsites.aem.live/government/american_rescue_plan_act/
