### PR TITLE
fix : Change document center class names as they match with global search

### DIFF
--- a/blocks/document-center/document-center.css
+++ b/blocks/document-center/document-center.css
@@ -56,7 +56,7 @@
         }
     }
 
-    .content, .search-results {
+    .content, .doc-search-results {
         ul {
             padding: 10px 15px;
             list-style-type: none;
@@ -133,7 +133,7 @@
     }
 }
 
-.search-form {
+.doc-search-form {
     label {
         font-weight: bold;
         margin-bottom: 10px;
@@ -154,7 +154,7 @@
         border: 1px solid #22497d;
     }
 
-    .search-button {
+    .doc-search-button {
         padding: 10px 20px;
         background: #0094C3;
         color: #fff;
@@ -165,7 +165,7 @@
         cursor: pointer;
     }
 
-    .reset-button {
+    .doc-reset-button {
         margin-top: 20px;
         padding: 10px 20px;
         background-color: #C52E2E;

--- a/blocks/document-center/document-center.js
+++ b/blocks/document-center/document-center.js
@@ -66,8 +66,8 @@ function searchDocuments(searchValue) {
     }
   });
 
-  document.querySelector('.reset-button').style.display = 'block';
-  const searchResults = document.querySelector('.search-results');
+  document.querySelector('.doc-reset-button').style.display = 'block';
+  const searchResults = document.querySelector('.doc-search-results');
   searchResults.innerHTML = '';
 
   if (results.length === 0) {
@@ -85,7 +85,7 @@ function searchDocuments(searchValue) {
 }
 
 function searchFile() {
-  const searchValue = document.querySelector('.search-input').value.trim().toUpperCase();
+  const searchValue = document.querySelector('.doc-search-input').value.trim().toUpperCase();
 
   if (searchValue.length > 0 && searchValue !== oldSearch) {
     searchDocuments(searchValue.toUpperCase());
@@ -93,22 +93,22 @@ function searchFile() {
 }
 
 function clearSearch(element) {
-  document.querySelector('.search-input').value = '';
-  slideUp(document.querySelector('.search-results'));
+  document.querySelector('.doc-search-input').value = '';
+  slideUp(document.querySelector('.doc-search-results'));
   slideDown(document.querySelector('.documents-wrap'));
   element.style.display = 'none';
   oldSearch = '';
 }
 
 function createFileSearchForm(block) {
-  const searchLabel = label({ class: 'search-label', for: 'file-search' }, h2('Search for file name:'));
+  const searchLabel = label({ class: 'doc-search-label', for: 'file-search' }, h2('Search for file name:'));
   const searchInput = input({
-    class: 'search-input', type: 'text', placeholder: 'search here', onkeypress: (e) => { if (e.key === 'Enter') searchFile(); },
+    class: 'doc-search-input', type: 'text', placeholder: 'search here', onkeypress: (e) => { if (e.key === 'Enter') searchFile(); },
   });
-  const searchButton = button({ class: 'search-button', onclick: () => searchFile() }, 'Search');
-  const resetButton = button({ class: 'reset-button', onclick(e) { clearSearch(this, e); } }, 'RESET');
+  const searchButton = button({ class: 'doc-search-button', onclick: () => searchFile() }, 'Search');
+  const resetButton = button({ class: 'doc-reset-button', onclick(e) { clearSearch(this, e); } }, 'RESET');
   const searchForm = div(
-    { class: 'search-form' },
+    { class: 'doc-search-form' },
     searchLabel,
     searchInput,
     searchButton,
@@ -118,7 +118,7 @@ function createFileSearchForm(block) {
 }
 
 export default function decorate(block) {
-  const searchResults = div({ class: 'search-results' });
+  const searchResults = div({ class: 'doc-search-results' });
   const container = div({ class: 'documents-wrap' });
   [...block.children].forEach((row) => {
     // decorate accordion item label
@@ -148,12 +148,6 @@ export default function decorate(block) {
     const detailsEl = details({ class: 'accordion-item' }, summaryEl, body);
     container.append(detailsEl);
     row.remove();
-
-    /* const aElems = block.querySelectorAll('.content a');
-    aElems.forEach((aElem) => {
-      aElem.classList.remove('button');
-      aElem.setAttribute('target', '_blank');
-    }); */
   });
   block.append(searchResults);
   block.append(container);

--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -61,6 +61,15 @@
   left: 7px;
 }
 
+.embed.left-half {
+    margin: 20px 70px 20px 0;
+    max-width: 60%;
+
+    & > div {
+        justify-content: left;
+    }
+}
+
 /* CSS for iframe embed forms */
 
 main .mainmenu .section.rightsection.googleform .block.embed > div {

--- a/blocks/hotline/hotline.css
+++ b/blocks/hotline/hotline.css
@@ -5,7 +5,7 @@
     margin-top: 50px;
 }
 
-.search-form {
+.hotline-search-form {
     border: 1px solid #6a6a6a;
     display: block;
     position: relative;

--- a/blocks/hotline/hotline.js
+++ b/blocks/hotline/hotline.js
@@ -44,7 +44,7 @@ function handleTagSearch(element) {
 }
 
 function handleTextSearch() {
-  const searchValue = document.querySelector('.search-input').value.trim();
+  const searchValue = document.querySelector('.hotline-search-input').value.trim();
   if (searchValue != null && searchValue.length === 0) {
     displayAllBlocks();
   }
@@ -62,9 +62,9 @@ function buildCategoryTags(categories) {
 
 function buildSearchForm() {
   const form = div(
-    { class: 'search-form' },
+    { class: 'hotline-search-form' },
     input({
-      class: 'search-input', placeholder: 'Search...', name: 'business-search', type: 'text',
+      class: 'hotline-search-input', placeholder: 'Search...', name: 'business-search', type: 'text',
     }),
   );
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):
Fixes search mentioned in #572

Fix #

Test URLs:
- Before: https://main--clarkcountynv--aemsites.aem.live/government/departments/elections/reports_data_maps/political-district-maps
- After: https://issue572-doc-center-search--clarkcountynv--aemsites.aem.live/government/departments/elections/reports_data_maps/political-district-maps
- Before: https://main--clarkcountynv--aemsites.aem.live/government/departments/elections/reports_data_maps/pol-dist-maps-2021-redist
- After: https://issue572-doc-center-search--clarkcountynv--aemsites.aem.live/government/departments/elections/reports_data_maps/pol-dist-maps-2021-redist
- Before: https://main--clarkcountynv--aemsites.aem.page/residents/truancy_prevention_outreach_program/tpop-contracted-providers
- After: https://issue572-doc-center-search--clarkcountynv--aemsites.aem.page/residents/truancy_prevention_outreach_program/tpop-contracted-providers
