### PR TITLE
Fixing the calender event links bug

### DIFF
--- a/templates/calendar/calendar.js
+++ b/templates/calendar/calendar.js
@@ -448,7 +448,7 @@ function createCalendar() {
       }
     },
   });
-  calendar.render();
+  /* The Below code is for when the URL is loaded with a specific date */
   const windowHref = window.location.href;
   const url = new URL(windowHref);
   const view = url.searchParams.get('view');
@@ -476,6 +476,7 @@ function createCalendar() {
       }
     }
   }, 1);
+  calendar.render();
 }
 
 async function getFeaturedEvents() {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #1051 

Test URLs:
- Before: https://main--clarkcountynv--aemsites.aem.live/calendar
- After: https://issue1051--clarkcountynv--aemsites.aem.live/calendar
