### PR TITLE
Add style for embed block to left align video and allow content on right

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -79,6 +79,17 @@
   }
 }
 
+.embed.style-align-left-with-content {
+    max-width: 50%;
+    margin: 20px 70px 20px 0;
+
+    div {
+        float: left;
+        margin-right: 20px;
+        margin-bottom: 20px;
+    }
+}
+
 
 /* CSS for iframe embed forms */
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--clarkcountynv--aemsites.aem.live/government/departments/parks___recreation/wetlands_park/playinstallation
- After: https://embed-block-style--clarkcountynv--aemsites.aem.live/government/departments/parks___recreation/wetlands_park/playinstallation
