### PR TITLE
fix: Fix for extra space added after underline

### DIFF
--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -471,6 +471,10 @@ main .mainmenu .rightsection .table.no-header.cards.withimages.height-300 table 
     width: 170px;
 }
 
+.table.fixed-img-300 img{
+    width: 300px;
+}
+
 .table.col-odd-15 table tbody tr {
     td:nth-child(odd) {
         width: 15%;

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -65,6 +65,16 @@ export default async function decorate(block) {
       });
     }
   });
+
+  // Add a fix for extra space added after underline when a part of the word.
+  // Same logic can be used in other blocks when required
+  table.querySelectorAll('u').forEach((el) => {
+    const next = el.nextSibling;
+    if (next && next.nodeName === '#text') {
+      next.textContent = next.textContent.replace(/^ +/, '');
+    }
+  });
+
   block.innerHTML = '';
   block.append(table);
 }

--- a/blocks/text/text.css
+++ b/blocks/text/text.css
@@ -99,6 +99,10 @@ main .block.text {
         background-color: #f5e7b8;
     }
 
+    &.highlight-color-dark-blue {
+        background-color: #3598db;
+    }
+
     &.align-text-right {
         text-align: right;
     }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #821

Test URLs:
- Before: https://main--clarkcountynv--aemsites.aem.live/residents/assistance_programs/youth-services
- After: https://style-fixes--clarkcountynv--aemsites.aem.live/residents/assistance_programs/youth-services
