### PR TITLE
Reduce browser console error for blocks used as style

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -560,6 +560,11 @@ function buildBlock(blockName, content) {
   return blockEl;
 }
 
+function shouldIgnoreStylingBlock(blockName) {
+  const BLOCKS_TO_IGNORE = ['line-break', 'h2underline'];
+  return BLOCKS_TO_IGNORE.includes(blockName);
+}
+
 /**
  * Loads JS and CSS for a block.
  * @param {Element} block The block element
@@ -569,6 +574,9 @@ async function loadBlock(block) {
   if (status !== 'loading' && status !== 'loaded') {
     block.dataset.blockStatus = 'loading';
     const { blockName } = block.dataset;
+    if (shouldIgnoreStylingBlock(blockName)) {
+      return block;
+    }
     try {
       const cssLoaded = loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`);
       const decorationComplete = new Promise((resolve) => {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):
<img width="1058" alt="Screenshot 2025-05-22 at 3 09 11 PM" src="https://github.com/user-attachments/assets/cfeaba8f-c17d-4015-8e48-ef47ddb67564" />

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--clarkcountynv--aemsites.aem.page/government/departments/parks___recreation/wetlands_park/interpretiveprograms#family-programs-educational-tabletops
- After: https://misc-fixes--clarkcountynv--aemsites.aem.page/government/departments/parks___recreation/wetlands_park/interpretiveprograms#family-programs-educational-tabletops
- Before: https://main--clarkcountynv--aemsites.aem.page/drafts/akasjain/property-search
- After: https://misc-fixes--clarkcountynv--aemsites.aem.page/drafts/akasjain/property-search
