### PR TITLE
fix: remove fstab.yaml

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,2 +1,0 @@
-mountpoints:
-  /: https://clarkcountynv.sharepoint.com/teams/AEM/ClarkCountyNV/Website


### PR DESCRIPTION
This site is using the config service and does not require an `fstab`.

https://www.aem.live/docs/config-service-setup#remove-unused-configuration-files

Test URLs:
- Before: https://main--clarkcountynv--aemsites.aem.live/
- After: https://remove-fstab--clarkcountynv--aemsites.aem.live/
