### PR TITLE
Removed overflow from calendar modal

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -16,7 +16,6 @@ body.modal-open {
 
 .modal dialog .modal-content {
   box-sizing: border-box;
-  overflow-y: auto;
   overscroll-behavior: none;
   width: 100%;
   max-height: calc(100dvh - (2 * var(--header-height)) - 48px);
@@ -177,7 +176,6 @@ body.modal-open {
 
 /* Calendar Event Modal */
 .modal.event-modal-block dialog {
-  overflow-y: scroll;
   width: 100%;
   max-width: 390px;
   height: 100%;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--clarkcountynv}--aemsites.aem.live/
- After: https://1551-pc-users--clarkcountynv--aemsites.aem.live/calendar?view=month&day=01&month=08&year=2025
