### PR TITLE
change audio links from DAM to have default display text of "Audio"

### DIFF
--- a/tools/assets-selector/config.json
+++ b/tools/assets-selector/config.json
@@ -22,7 +22,7 @@
       },
       {
         "mimeType": "audio/*",
-        "value": "<a href=\"${videoUrl}\">${name}</a>"
+        "value": "<a href=\"${videoUrl}\">Audio</a>"
       }
     ],
     "copyMode": [


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--clarkcountynv--aemsites.aem.page/
- After: https://assets-selector-audiochange--clarkcountynv--aemsites.aem.page/
